### PR TITLE
Darkens scroll bar backgrounds

### DIFF
--- a/Carmesim.sublime-theme
+++ b/Carmesim.sublime-theme
@@ -228,7 +228,7 @@
     {
         "class": "scroll_bar_control",
         "layer0.texture": "",
-        "layer0.tint": [68, 71, 90], // -01
+        "layer0.tint": [40, 42, 54], // -01
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "blur": true
@@ -238,7 +238,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint": [68, 71, 90], // -01
+        "layer0.tint": [40, 42, 54], // -01
         "layer0.inner_margin": [0,0],
         "blur": true
     },


### PR DESCRIPTION
@sergiokopplin 

Changing the scroll bar colors to be darker than the puck seems to work for me on Linux Mint. I'm not familiar with Sublime Text theming, so you'll probably want to look this over and make sure I didn't cause any side effects.
