### PR TITLE
Fix ugly new tabs (#4)

### DIFF
--- a/Carmesim.sublime-theme
+++ b/Carmesim.sublime-theme
@@ -67,6 +67,8 @@
     // Tab close button
     {
         "class": "tab_close_button",
+        "layer0.texture": "Theme - Carmesim/Carmesim/close.png",
+        "layer0.opacity": 0,
         "layer0.tint": [101, 115, 126] // 03
     },
     {


### PR DESCRIPTION
This Fixes #4 . Instead of displaying ugly boxes for unhovered tabs, it simply displays "nothing" using the `close.png` texture but with an opacity of `0`.

I made these changes locally and rebuilt a SublimePackage myself and it worked, here's the before and after screenshots:
## Before

![](https://cloud.githubusercontent.com/assets/949223/6801696/757b131e-d22a-11e4-88fd-16d0d5b691e6.png)
## After

![screen shot 2015-04-01 at 3 28 17 pm](https://cloud.githubusercontent.com/assets/949223/6941891/c45e2502-d883-11e4-836f-75afabe15d86.png)
